### PR TITLE
Make privileged action be a FnOnce()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
-name = "daemonize"
+name = "cf-daemonize"
 version = "0.3.0"
 license = "MIT/Apache-2.0"
 authors = ["Fedor Gogolev <knsd@knsd.net>"]
-repository = "https://github.com/knsd/daemonize"
-documentation = "https://docs.rs/daemonize"
+repository = "https://github.com/cloudflare/daemonize"
 readme = "README.md"
-description = "Library to enable your code run as a daemon process on Unix-like systems."
-keywords = ["daemon", "daemonize", "unix"]
-categories = ["os::unix-apis"]
+description = "A (hopefully temporary) fork of the `daemonize` crate."
 
 [dependencies]
 libc = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -1,50 +1,11 @@
-daemonize [![Build Status](https://travis-ci.org/knsd/daemonize.svg?branch=master)](https://travis-ci.org/knsd/daemonize) [![Latest Version](https://img.shields.io/crates/v/daemonize.svg)](https://crates.io/crates/daemonize/) [![docs](https://docs.rs/daemonize/badge.svg)](https://docs.rs/daemonize)
-=========
+# cf-daemonize
 
+This project contains a fork of the [`daemonize` crate], for use in
+Cloudflare's [`boringtun`](https://github.com/cloudflare/boringtun). 
+We'd prefer to upstream the changes, but the original project appears
+to be inactive at the moment.
 
-daemonize is a library for writing system daemons. Inspired by the Python library [thesharp/daemonize](https://github.com/thesharp/daemonize).
+Unless you depend on the specific additional features of this fork, 
+we recommend that you use the original [`daemonize` crate].
 
-Usage example:
-
-```rust
-extern crate daemonize;
-
-use std::fs::File;
-
-use daemonize::Daemonize;
-
-fn main() {
-    let stdout = File::create("/tmp/daemon.out").unwrap();
-    let stderr = File::create("/tmp/daemon.err").unwrap();
-
-    let daemonize = Daemonize::new()
-        .pid_file("/tmp/test.pid") // Every method except `new` and `start`
-        .chown_pid_file(true)      // is optional, see `Daemonize` documentation
-        .working_directory("/tmp") // for default behaviour.
-        .user("nobody")
-        .group("daemon") // Group name
-        .group(2)        // or group id.
-        .umask(0o777)    // Set umask, `0o027` by default.
-        .stdout(stdout)  // Redirect stdout to `/tmp/daemon.out`.
-        .stderr(stderr)  // Redirect stderr to `/tmp/daemon.err`.
-        .privileged_action(|| "Executed before drop privileges");
-
-    match daemonize.start() {
-        Ok(_) => println!("Success, daemonized"),
-        Err(e) => eprintln!("Error, {}", e),
-    }
-}
-```
-
-### License
-
-Licensed under either of
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-at your option.
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you shall be dual licensed as above, without any
-additional terms or conditions.
+[`daemonize` crate]: https://github.com/knsd/daemonize

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -10,14 +10,14 @@ fn main() {
 
     let daemonize = Daemonize::new()
         .pid_file("/tmp/test.pid") // Every method except `new` and `start`
-        .chown_pid_file(true)      // is optional, see `Daemonize` documentation
+        .chown_pid_file(true) // is optional, see `Daemonize` documentation
         .working_directory("/tmp") // for default behaviour.
         .user("nobody")
         .group("daemon") // Group name
-        .group(2)        // or group id.
-        .umask(0o777)    // Set umask, `0o027` by default.
-        .stdout(stdout)  // Redirect stdout to `/tmp/daemon.out`.
-        .stderr(stderr)  // Redirect stderr to `/tmp/daemon.err`.
+        .group(2) // or group id.
+        .umask(0o777) // Set umask, `0o027` by default.
+        .stdout(stdout) // Redirect stdout to `/tmp/daemon.out`.
+        .stderr(stderr) // Redirect stderr to `/tmp/daemon.err`.
         .privileged_action(|| "Executed before drop privileges");
 
     match daemonize.start() {

--- a/examples/test_chdir.rs
+++ b/examples/test_chdir.rs
@@ -2,7 +2,7 @@ extern crate daemonize;
 
 use std::io::prelude::*;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -10,6 +10,13 @@ fn main() {
     let ref file = args[2];
     let umask = args[3].parse().unwrap();
 
-    Daemonize::new().working_directory(chdir).umask(umask).start().unwrap();
-    std::fs::File::create(file).unwrap().write_all(b"test").unwrap();
+    Daemonize::new()
+        .working_directory(chdir)
+        .umask(umask)
+        .start()
+        .unwrap();
+    std::fs::File::create(file)
+        .unwrap()
+        .write_all(b"test")
+        .unwrap();
 }

--- a/examples/test_chown_pid.rs
+++ b/examples/test_chown_pid.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -8,5 +8,10 @@ fn main() {
     let ref group = *args[2];
     let ref pid = *args[3];
 
-    Daemonize::new().pid_file(pid).user(user).group(group).start().unwrap();
+    Daemonize::new()
+        .pid_file(pid)
+        .user(user)
+        .group(group)
+        .start()
+        .unwrap();
 }

--- a/examples/test_double_run.rs
+++ b/examples/test_double_run.rs
@@ -1,7 +1,7 @@
 extern crate daemonize;
 
+use daemonize::Daemonize;
 use std::io::prelude::*;
-use daemonize::{Daemonize};
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -13,8 +13,7 @@ fn main() {
         Ok(()) => {
             file.write_all(b"ok").unwrap();
             std::thread::sleep(std::time::Duration::from_secs(10));
-
-        },
+        }
         Err(_) => file.write_all(b"error").unwrap(),
     };
 }

--- a/examples/test_pid.rs
+++ b/examples/test_pid.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();

--- a/examples/test_redirect_streams.rs
+++ b/examples/test_redirect_streams.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -10,7 +10,11 @@ fn main() {
     let stdout = std::fs::File::create(stdout).unwrap();
     let stderr = std::fs::File::create(stderr).unwrap();
 
-    Daemonize::new().stdout(stdout).stderr(stderr).start().unwrap();
+    Daemonize::new()
+        .stdout(stdout)
+        .stderr(stderr)
+        .start()
+        .unwrap();
 
     println!("stdout");
     println!("newline");

--- a/examples/test_uid_gid.rs
+++ b/examples/test_uid_gid.rs
@@ -3,7 +3,7 @@ extern crate libc;
 
 use std::io::prelude::*;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -14,6 +14,7 @@ fn main() {
     let mut file = std::fs::File::create(file).unwrap();
     Daemonize::new().user(user).group(group).start().unwrap();
     unsafe {
-        file.write_all(format!("{} {}", libc::getuid(), libc::getgid()).as_bytes()).unwrap();
+        file.write_all(format!("{} {}", libc::getuid(), libc::getgid()).as_bytes())
+            .unwrap();
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,30 +8,30 @@
 
 extern crate libc;
 
-use std::ffi::{CString};
+use std::ffi::CString;
 
 #[repr(C)]
 #[allow(dead_code)]
 struct passwd {
-    pw_name:   *const libc::c_char,
+    pw_name: *const libc::c_char,
     pw_passwd: *const libc::c_char,
-    pw_uid:    libc::uid_t,
-    pw_gid:    libc::gid_t,
-    pw_gecos:  *const libc::c_char,
-    pw_dir:    *const libc::c_char,
-    pw_shell:  *const libc::c_char,
+    pw_uid: libc::uid_t,
+    pw_gid: libc::gid_t,
+    pw_gecos: *const libc::c_char,
+    pw_dir: *const libc::c_char,
+    pw_shell: *const libc::c_char,
 }
 
 #[repr(C)]
 #[allow(dead_code)]
 struct group {
-    gr_name:   *const libc::c_char,
+    gr_name: *const libc::c_char,
     gr_passwd: *const libc::c_char,
-    gr_gid:    libc::gid_t,
-    gr_mem:    *const *const libc::c_char,
+    gr_gid: libc::gid_t,
+    gr_mem: *const *const libc::c_char,
 }
 
-extern {
+extern "C" {
     fn getgrnam(name: *const libc::c_char) -> *const group;
     fn getpwnam(name: *const libc::c_char) -> *const passwd;
     pub fn flock(fd: libc::c_int, operation: libc::c_int) -> libc::c_int;
@@ -81,10 +81,12 @@ mod tests {
 
     #[test]
     fn test_get_gid_by_name() {
-        let group_name = ::std::ffi::CString::new(match ::std::fs::metadata("/etc/debian_version") {
-            Ok(_) => "nogroup",
-            Err(_) => "nobody",
-        }).unwrap();
+        let group_name =
+            ::std::ffi::CString::new(match ::std::fs::metadata("/etc/debian_version") {
+                Ok(_) => "nogroup",
+                Err(_) => "nobody",
+            })
+            .unwrap();
         unsafe {
             let gid = get_gid_by_name(&group_name);
             assert_eq!(gid, Some(nobody_uid_gid()))

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
-extern crate tempdir;
 extern crate libc;
+extern crate tempdir;
 
+use std::ffi::OsStr;
 use std::io::prelude::*;
-use std::ffi::{OsStr};
 
-use tempdir::{TempDir};
+use tempdir::TempDir;
 
 fn run<S: AsRef<OsStr>>(cmd: S, args: &[S]) -> u32 {
     let mut cmd = std::process::Command::new(cmd);
@@ -29,7 +29,10 @@ fn test_umask_chdir() {
 
     let filename = tmpdir.path().join("test");
     let mut data = Vec::new();
-    std::fs::File::open(&filename).unwrap().read_to_end(&mut data).unwrap();
+    std::fs::File::open(&filename)
+        .unwrap()
+        .read_to_end(&mut data)
+        .unwrap();
     assert!(data == b"test");
     // due to the umask, the file should have been created with -w
     assert!(filename.metadata().unwrap().permissions().readonly());
@@ -44,7 +47,10 @@ fn test_pid() {
     let child_pid = run("target/debug/examples/test_pid", &args);
 
     let mut data = String::new();
-    std::fs::File::open(&pid_file).unwrap().read_to_string(&mut data).unwrap();
+    std::fs::File::open(&pid_file)
+        .unwrap()
+        .read_to_string(&mut data)
+        .unwrap();
     let pid: u32 = data.parse().unwrap();
     assert!(pid != child_pid)
 }
@@ -64,13 +70,19 @@ fn double_run() {
 
     {
         let mut data = String::new();
-        std::fs::File::open(&first_result).unwrap().read_to_string(&mut data).unwrap();
+        std::fs::File::open(&first_result)
+            .unwrap()
+            .read_to_string(&mut data)
+            .unwrap();
         assert!(data == "ok")
     }
 
     {
         let mut data = String::new();
-        std::fs::File::open(&second_result).unwrap().read_to_string(&mut data).unwrap();
+        std::fs::File::open(&second_result)
+            .unwrap()
+            .read_to_string(&mut data)
+            .unwrap();
         assert!(data == "error")
     }
 }
@@ -87,7 +99,10 @@ fn test_uid_gid() {
     let own_uid_gid_string = unsafe { format!("{} {}", libc::getuid(), libc::getgid()) };
 
     let mut data = String::new();
-    std::fs::File::open(&result_file).unwrap().read_to_string(&mut data).unwrap();
+    std::fs::File::open(&result_file)
+        .unwrap()
+        .read_to_string(&mut data)
+        .unwrap();
     assert!(!data.is_empty());
     assert!(data != own_uid_gid_string)
 }
@@ -104,10 +119,16 @@ fn test_redirect_streams() {
     std::thread::sleep(std::time::Duration::from_millis(100));
 
     let mut stdout = String::new();
-    std::fs::File::open(&stdout_file).unwrap().read_to_string(&mut stdout).unwrap();
+    std::fs::File::open(&stdout_file)
+        .unwrap()
+        .read_to_string(&mut stdout)
+        .unwrap();
 
     let mut stderr = String::new();
-    std::fs::File::open(&stderr_file).unwrap().read_to_string(&mut stderr).unwrap();
+    std::fs::File::open(&stderr_file)
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
 
     assert_eq!(stdout, "stdout\nnewline\n");
     assert_eq!(stderr, "stderr\nnewline\n");


### PR DESCRIPTION
I really think privileged_action should be a FnOnce(), it makes it much easier to move stuff into the closure.

Otherwise you get an [E0507](https://doc.rust-lang.org/error-index.html#E0507) in many standard use-cases.

Hope this helps.