### PR TITLE
Allow an exit action, to wait for a signal from a child (also cargo fmt)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
-name = "daemonize"
+name = "cf-daemonize"
 version = "0.3.0"
 license = "MIT/Apache-2.0"
 authors = ["Fedor Gogolev <knsd@knsd.net>"]
-repository = "https://github.com/knsd/daemonize"
-documentation = "https://docs.rs/daemonize"
+repository = "https://github.com/cloudflare/daemonize"
 readme = "README.md"
-description = "Library to enable your code run as a daemon process on Unix-like systems."
-keywords = ["daemon", "daemonize", "unix"]
-categories = ["os::unix-apis"]
+description = "A (hopefully temporary) fork of the `daemonize` crate."
 
 [dependencies]
 libc = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -1,50 +1,11 @@
-daemonize [![Build Status](https://travis-ci.org/knsd/daemonize.svg?branch=master)](https://travis-ci.org/knsd/daemonize) [![Latest Version](https://img.shields.io/crates/v/daemonize.svg)](https://crates.io/crates/daemonize/) [![docs](https://docs.rs/daemonize/badge.svg)](https://docs.rs/daemonize)
-=========
+# cf-daemonize
 
+This project contains a fork of the [`daemonize` crate], for use in
+Cloudflare's [`boringtun`](https://github.com/cloudflare/boringtun). 
+We'd prefer to upstream the changes, but the original project appears
+to be inactive at the moment.
 
-daemonize is a library for writing system daemons. Inspired by the Python library [thesharp/daemonize](https://github.com/thesharp/daemonize).
+Unless you depend on the specific additional features of this fork, 
+we recommend that you use the original [`daemonize` crate].
 
-Usage example:
-
-```rust
-extern crate daemonize;
-
-use std::fs::File;
-
-use daemonize::Daemonize;
-
-fn main() {
-    let stdout = File::create("/tmp/daemon.out").unwrap();
-    let stderr = File::create("/tmp/daemon.err").unwrap();
-
-    let daemonize = Daemonize::new()
-        .pid_file("/tmp/test.pid") // Every method except `new` and `start`
-        .chown_pid_file(true)      // is optional, see `Daemonize` documentation
-        .working_directory("/tmp") // for default behaviour.
-        .user("nobody")
-        .group("daemon") // Group name
-        .group(2)        // or group id.
-        .umask(0o777)    // Set umask, `0o027` by default.
-        .stdout(stdout)  // Redirect stdout to `/tmp/daemon.out`.
-        .stderr(stderr)  // Redirect stderr to `/tmp/daemon.err`.
-        .privileged_action(|| "Executed before drop privileges");
-
-    match daemonize.start() {
-        Ok(_) => println!("Success, daemonized"),
-        Err(e) => eprintln!("Error, {}", e),
-    }
-}
-```
-
-### License
-
-Licensed under either of
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-at your option.
-
-### Contribution
-
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you shall be dual licensed as above, without any
-additional terms or conditions.
+[`daemonize` crate]: https://github.com/knsd/daemonize

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -10,14 +10,14 @@ fn main() {
 
     let daemonize = Daemonize::new()
         .pid_file("/tmp/test.pid") // Every method except `new` and `start`
-        .chown_pid_file(true)      // is optional, see `Daemonize` documentation
+        .chown_pid_file(true) // is optional, see `Daemonize` documentation
         .working_directory("/tmp") // for default behaviour.
         .user("nobody")
         .group("daemon") // Group name
-        .group(2)        // or group id.
-        .umask(0o777)    // Set umask, `0o027` by default.
-        .stdout(stdout)  // Redirect stdout to `/tmp/daemon.out`.
-        .stderr(stderr)  // Redirect stderr to `/tmp/daemon.err`.
+        .group(2) // or group id.
+        .umask(0o777) // Set umask, `0o027` by default.
+        .stdout(stdout) // Redirect stdout to `/tmp/daemon.out`.
+        .stderr(stderr) // Redirect stderr to `/tmp/daemon.err`.
         .privileged_action(|| "Executed before drop privileges");
 
     match daemonize.start() {

--- a/examples/test_chdir.rs
+++ b/examples/test_chdir.rs
@@ -2,7 +2,7 @@ extern crate daemonize;
 
 use std::io::prelude::*;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -10,6 +10,13 @@ fn main() {
     let ref file = args[2];
     let umask = args[3].parse().unwrap();
 
-    Daemonize::new().working_directory(chdir).umask(umask).start().unwrap();
-    std::fs::File::create(file).unwrap().write_all(b"test").unwrap();
+    Daemonize::new()
+        .working_directory(chdir)
+        .umask(umask)
+        .start()
+        .unwrap();
+    std::fs::File::create(file)
+        .unwrap()
+        .write_all(b"test")
+        .unwrap();
 }

--- a/examples/test_chown_pid.rs
+++ b/examples/test_chown_pid.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -8,5 +8,10 @@ fn main() {
     let ref group = *args[2];
     let ref pid = *args[3];
 
-    Daemonize::new().pid_file(pid).user(user).group(group).start().unwrap();
+    Daemonize::new()
+        .pid_file(pid)
+        .user(user)
+        .group(group)
+        .start()
+        .unwrap();
 }

--- a/examples/test_double_run.rs
+++ b/examples/test_double_run.rs
@@ -1,7 +1,7 @@
 extern crate daemonize;
 
+use daemonize::Daemonize;
 use std::io::prelude::*;
-use daemonize::{Daemonize};
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -13,8 +13,7 @@ fn main() {
         Ok(()) => {
             file.write_all(b"ok").unwrap();
             std::thread::sleep(std::time::Duration::from_secs(10));
-
-        },
+        }
         Err(_) => file.write_all(b"error").unwrap(),
     };
 }

--- a/examples/test_pid.rs
+++ b/examples/test_pid.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();

--- a/examples/test_redirect_streams.rs
+++ b/examples/test_redirect_streams.rs
@@ -1,6 +1,6 @@
 extern crate daemonize;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -10,7 +10,11 @@ fn main() {
     let stdout = std::fs::File::create(stdout).unwrap();
     let stderr = std::fs::File::create(stderr).unwrap();
 
-    Daemonize::new().stdout(stdout).stderr(stderr).start().unwrap();
+    Daemonize::new()
+        .stdout(stdout)
+        .stderr(stderr)
+        .start()
+        .unwrap();
 
     println!("stdout");
     println!("newline");

--- a/examples/test_uid_gid.rs
+++ b/examples/test_uid_gid.rs
@@ -3,7 +3,7 @@ extern crate libc;
 
 use std::io::prelude::*;
 
-use daemonize::{Daemonize};
+use daemonize::Daemonize;
 
 fn main() {
     let args = std::env::args().collect::<Vec<String>>();
@@ -14,6 +14,7 @@ fn main() {
     let mut file = std::fs::File::create(file).unwrap();
     Daemonize::new().user(user).group(group).start().unwrap();
     unsafe {
-        file.write_all(format!("{} {}", libc::getuid(), libc::getgid()).as_bytes()).unwrap();
+        file.write_all(format!("{} {}", libc::getuid(), libc::getgid()).as_bytes())
+            .unwrap();
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -8,30 +8,30 @@
 
 extern crate libc;
 
-use std::ffi::{CString};
+use std::ffi::CString;
 
 #[repr(C)]
 #[allow(dead_code)]
 struct passwd {
-    pw_name:   *const libc::c_char,
+    pw_name: *const libc::c_char,
     pw_passwd: *const libc::c_char,
-    pw_uid:    libc::uid_t,
-    pw_gid:    libc::gid_t,
-    pw_gecos:  *const libc::c_char,
-    pw_dir:    *const libc::c_char,
-    pw_shell:  *const libc::c_char,
+    pw_uid: libc::uid_t,
+    pw_gid: libc::gid_t,
+    pw_gecos: *const libc::c_char,
+    pw_dir: *const libc::c_char,
+    pw_shell: *const libc::c_char,
 }
 
 #[repr(C)]
 #[allow(dead_code)]
 struct group {
-    gr_name:   *const libc::c_char,
+    gr_name: *const libc::c_char,
     gr_passwd: *const libc::c_char,
-    gr_gid:    libc::gid_t,
-    gr_mem:    *const *const libc::c_char,
+    gr_gid: libc::gid_t,
+    gr_mem: *const *const libc::c_char,
 }
 
-extern {
+extern "C" {
     fn getgrnam(name: *const libc::c_char) -> *const group;
     fn getpwnam(name: *const libc::c_char) -> *const passwd;
     pub fn flock(fd: libc::c_int, operation: libc::c_int) -> libc::c_int;
@@ -81,10 +81,12 @@ mod tests {
 
     #[test]
     fn test_get_gid_by_name() {
-        let group_name = ::std::ffi::CString::new(match ::std::fs::metadata("/etc/debian_version") {
-            Ok(_) => "nogroup",
-            Err(_) => "nobody",
-        }).unwrap();
+        let group_name =
+            ::std::ffi::CString::new(match ::std::fs::metadata("/etc/debian_version") {
+                Ok(_) => "nogroup",
+                Err(_) => "nobody",
+            })
+            .unwrap();
         unsafe {
             let gid = get_gid_by_name(&group_name);
             assert_eq!(gid, Some(nobody_uid_gid()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,37 +43,40 @@
 //! }
 //! ```
 
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 mod ffi;
 
 extern crate libc;
 
+use std::env::set_current_dir;
+use std::ffi::CString;
 use std::fmt;
-use std::io;
-use std::env::{set_current_dir};
-use std::ffi::{CString};
 use std::fs::File;
+use std::io;
+use std::mem::transmute;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::AsRawFd;
-use std::mem::{transmute};
 use std::path::{Path, PathBuf};
-use std::process::{exit};
+use std::process::exit;
 
-pub use libc::{uid_t, gid_t, mode_t};
-use libc::{LOCK_EX, LOCK_NB, c_int, open, write, close, ftruncate, fork, getpid, setsid, setuid, setgid, dup2, umask};
+use libc::{
+    c_int, close, dup2, fork, ftruncate, getpid, open, setgid, setsid, setuid, umask, write,
+    LOCK_EX, LOCK_NB,
+};
+pub use libc::{gid_t, mode_t, uid_t};
 
 use self::ffi::{chroot, flock, get_gid_by_name, get_uid_by_name};
 
 macro_rules! tryret {
-    ($expr:expr, $ret:expr, $err:expr) => (
+    ($expr:expr, $ret:expr, $err:expr) => {
         if $expr == -1 {
-            return Err($err(errno()))
+            return Err($err(errno()));
         } else {
             $ret
         }
-    )
+    };
 }
 
 pub type Errno = c_int;
@@ -137,7 +140,9 @@ impl DaemonizeError {
             DaemonizeError::OpenPidfile => "unable to open pid file",
             DaemonizeError::LockPidfile(_) => "unable to lock pid file",
             DaemonizeError::ChownPidfile(_) => "unable to chown pid file",
-            DaemonizeError::RedirectStreams(_) => "unable to redirect standard streams to /dev/null",
+            DaemonizeError::RedirectStreams(_) => {
+                "unable to redirect standard streams to /dev/null"
+            }
             DaemonizeError::WritePid => "unable to write self pid to pid file",
             DaemonizeError::Chroot(_) => "unable to chroot into directory",
             DaemonizeError::__Nonexhaustive => unreachable!(),
@@ -206,13 +211,13 @@ enum StdioImp {
 /// Describes what to do with a standard I/O stream for a child process.
 #[derive(Debug)]
 pub struct Stdio {
-    inner: StdioImp
+    inner: StdioImp,
 }
 
 impl Stdio {
     fn devnull() -> Self {
         Self {
-            inner: StdioImp::Devnull
+            inner: StdioImp::Devnull,
         }
     }
 }
@@ -220,7 +225,7 @@ impl Stdio {
 impl From<File> for Stdio {
     fn from(file: File) -> Self {
         Self {
-            inner: StdioImp::RedirectToFile(file)
+            inner: StdioImp::RedirectToFile(file),
         }
     }
 }
@@ -249,6 +254,7 @@ pub struct Daemonize<T> {
     umask: mode_t,
     root: Option<PathBuf>,
     privileged_action: Box<Fn() -> T>,
+    exit_action: Box<Fn()>,
     stdin: Stdio,
     stdout: Stdio,
     stderr: Stdio,
@@ -272,7 +278,6 @@ impl<T> fmt::Debug for Daemonize<T> {
 }
 
 impl Daemonize<()> {
-
     pub fn new() -> Self {
         Daemonize {
             directory: Path::new("/").to_owned(),
@@ -282,6 +287,7 @@ impl Daemonize<()> {
             group: None,
             umask: 0o027,
             privileged_action: Box::new(|| ()),
+            exit_action: Box::new(|| ()),
             root: None,
             stdin: Stdio::devnull(),
             stdout: Stdio::devnull(),
@@ -291,7 +297,6 @@ impl Daemonize<()> {
 }
 
 impl<T> Daemonize<T> {
-
     /// Create pid-file at `path`, lock it exclusive and write daemon pid.
     pub fn pid_file<F: AsRef<Path>>(mut self, path: F) -> Self {
         self.pid_file = Some(path.as_ref().to_owned());
@@ -342,6 +347,13 @@ impl<T> Daemonize<T> {
         new
     }
 
+    /// Execute `action` just before exitin from the parent process. Most common usecase is to wait for forked process.
+    pub fn exit_action<F: Fn() + Sized + 'static>(self, action: F) -> Daemonize<T> {
+        let mut new: Daemonize<T> = unsafe { transmute(self) };
+        new.exit_action = Box::new(action);
+        new
+    }
+
     /// Configuration for the child process's standard output stream.
     pub fn stdout<S: Into<Stdio>>(mut self, stdio: S) -> Self {
         self.stdout = stdio.into();
@@ -359,26 +371,30 @@ impl<T> Daemonize<T> {
         // Maps an Option<T> to Option<U> by applying a function Fn(T) -> Result<U, DaemonizeError>
         // to a contained value and try! it's result
         macro_rules! maptry {
-            ($expr:expr, $f: expr) => (
+            ($expr:expr, $f: expr) => {
                 match $expr {
                     None => None,
-                    Some(x) => Some(try!($f(x)))
+                    Some(x) => Some(try!($f(x))),
                 };
-            )
+            };
         }
 
         unsafe {
             let pid_file_fd = maptry!(self.pid_file.clone(), create_pid_file);
 
-            try!(perform_fork());
+            try!(self.perform_fork(true));
 
-            try!(set_current_dir(self.directory).map_err(|_| DaemonizeError::ChangeDirectory));
+            try!(set_current_dir(&self.directory).map_err(|_| DaemonizeError::ChangeDirectory));
             try!(set_sid());
             umask(self.umask);
 
-            try!(perform_fork());
+            try!(self.perform_fork(false));
 
-            try!(redirect_standard_streams(self.stdin, self.stdout, self.stderr));
+            try!(redirect_standard_streams(
+                self.stdin,
+                self.stdout,
+                self.stderr
+            ));
 
             let uid = maptry!(self.user, get_user);
             let gid = maptry!(self.group, get_group);
@@ -389,7 +405,7 @@ impl<T> Daemonize<T> {
                     (Some(pid), None, Some(gid)) => Some((pid, uid_t::max_value() - 1, gid)),
                     (Some(pid), Some(uid), None) => Some((pid, uid, gid_t::max_value() - 1)),
                     // Or pid file is not provided, or both user and group
-                    _ => None
+                    _ => None,
                 };
 
                 maptry!(args, |(pid, uid, gid)| chown_pid_file(pid, uid, gid));
@@ -408,16 +424,18 @@ impl<T> Daemonize<T> {
         }
     }
 
-}
-
-unsafe fn perform_fork() -> Result<()> {
-    let pid = fork();
-    if pid < 0 {
-        Err(DaemonizeError::Fork)
-    } else if pid == 0 {
-        Ok(())
-    } else {
-        exit(0)
+    unsafe fn perform_fork(&self, perform_action: bool) -> Result<()> {
+        let pid = fork();
+        if pid < 0 {
+            Err(DaemonizeError::Fork)
+        } else if pid == 0 {
+            Ok(())
+        } else {
+            if perform_action {
+                (self.exit_action)();
+            }
+            exit(0)
+        }
     }
 }
 
@@ -428,7 +446,7 @@ unsafe fn set_sid() -> Result<()> {
 unsafe fn redirect_standard_streams(stdin: Stdio, stdout: Stdio, stderr: Stdio) -> Result<()> {
     let devnull_fd = open(transmute(b"/dev/null\0"), libc::O_RDWR);
     if -1 == devnull_fd {
-        return Err(DaemonizeError::RedirectStreams(errno()))
+        return Err(DaemonizeError::RedirectStreams(errno()));
     }
 
     let process_stdio = |fd, stdio: Stdio| {
@@ -436,11 +454,11 @@ unsafe fn redirect_standard_streams(stdin: Stdio, stdout: Stdio, stderr: Stdio) 
         match stdio.inner {
             StdioImp::Devnull => {
                 tryret!(dup2(devnull_fd, fd), (), DaemonizeError::RedirectStreams);
-            },
+            }
             StdioImp::RedirectToFile(file) => {
                 let raw_fd = file.as_raw_fd();
                 tryret!(dup2(raw_fd, fd), (), DaemonizeError::RedirectStreams);
-            },
+            }
         };
         Ok(())
     };
@@ -461,7 +479,7 @@ unsafe fn get_group(group: Group) -> Result<gid_t> {
             let s = try!(CString::new(name).map_err(|_| DaemonizeError::GroupContainsNul));
             match get_gid_by_name(&s) {
                 Some(id) => get_group(Group::Id(id)),
-                None => Err(DaemonizeError::GroupNotFound)
+                None => Err(DaemonizeError::GroupNotFound),
             }
         }
     }
@@ -478,7 +496,7 @@ unsafe fn get_user(user: User) -> Result<uid_t> {
             let s = try!(CString::new(name).map_err(|_| DaemonizeError::UserContainsNul));
             match get_uid_by_name(&s) {
                 Some(id) => get_user(User::Id(id)),
-                None => Err(DaemonizeError::UserNotFound)
+                None => Err(DaemonizeError::UserNotFound),
             }
         }
     }
@@ -493,15 +511,23 @@ unsafe fn create_pid_file(path: PathBuf) -> Result<libc::c_int> {
 
     let fd = open(path_c.as_ptr(), libc::O_WRONLY | libc::O_CREAT, 0o666);
     if -1 == fd {
-        return Err(DaemonizeError::OpenPidfile)
+        return Err(DaemonizeError::OpenPidfile);
     }
 
-    tryret!(flock(fd, LOCK_EX | LOCK_NB), Ok(fd), DaemonizeError::LockPidfile)
+    tryret!(
+        flock(fd, LOCK_EX | LOCK_NB),
+        Ok(fd),
+        DaemonizeError::LockPidfile
+    )
 }
 
 unsafe fn chown_pid_file(path: PathBuf, uid: uid_t, gid: gid_t) -> Result<()> {
     let path_c = try!(pathbuf_into_cstring(path));
-    tryret!(libc::chown(path_c.as_ptr(), uid, gid), Ok(()), DaemonizeError::ChownPidfile)
+    tryret!(
+        libc::chown(path_c.as_ptr(), uid, gid),
+        Ok(()),
+        DaemonizeError::ChownPidfile
+    )
 }
 
 unsafe fn write_pid_file(fd: libc::c_int) -> Result<()> {
@@ -510,7 +536,7 @@ unsafe fn write_pid_file(fd: libc::c_int) -> Result<()> {
     let pid_length = pid_buf.len();
     let pid_c = CString::new(pid_buf).unwrap();
     if -1 == ftruncate(fd, 0) {
-        return Err(DaemonizeError::WritePid)
+        return Err(DaemonizeError::WritePid);
     }
     if write(fd, transmute(pid_c.as_ptr()), pid_length) < pid_length as isize {
         Err(DaemonizeError::WritePid)
@@ -530,8 +556,7 @@ unsafe fn change_root(path: PathBuf) -> Result<()> {
 }
 
 fn pathbuf_into_cstring(path: PathBuf) -> Result<CString> {
-    CString::new(path.into_os_string().into_vec())
-            .map_err(|_| DaemonizeError::PathContainsNul)
+    CString::new(path.into_os_string().into_vec()).map_err(|_| DaemonizeError::PathContainsNul)
 }
 
 fn errno() -> Errno {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
-extern crate tempdir;
 extern crate libc;
+extern crate tempdir;
 
+use std::ffi::OsStr;
 use std::io::prelude::*;
-use std::ffi::{OsStr};
 
-use tempdir::{TempDir};
+use tempdir::TempDir;
 
 fn run<S: AsRef<OsStr>>(cmd: S, args: &[S]) -> u32 {
     let mut cmd = std::process::Command::new(cmd);
@@ -29,7 +29,10 @@ fn test_umask_chdir() {
 
     let filename = tmpdir.path().join("test");
     let mut data = Vec::new();
-    std::fs::File::open(&filename).unwrap().read_to_end(&mut data).unwrap();
+    std::fs::File::open(&filename)
+        .unwrap()
+        .read_to_end(&mut data)
+        .unwrap();
     assert!(data == b"test");
     // due to the umask, the file should have been created with -w
     assert!(filename.metadata().unwrap().permissions().readonly());
@@ -44,7 +47,10 @@ fn test_pid() {
     let child_pid = run("target/debug/examples/test_pid", &args);
 
     let mut data = String::new();
-    std::fs::File::open(&pid_file).unwrap().read_to_string(&mut data).unwrap();
+    std::fs::File::open(&pid_file)
+        .unwrap()
+        .read_to_string(&mut data)
+        .unwrap();
     let pid: u32 = data.parse().unwrap();
     assert!(pid != child_pid)
 }
@@ -64,13 +70,19 @@ fn double_run() {
 
     {
         let mut data = String::new();
-        std::fs::File::open(&first_result).unwrap().read_to_string(&mut data).unwrap();
+        std::fs::File::open(&first_result)
+            .unwrap()
+            .read_to_string(&mut data)
+            .unwrap();
         assert!(data == "ok")
     }
 
     {
         let mut data = String::new();
-        std::fs::File::open(&second_result).unwrap().read_to_string(&mut data).unwrap();
+        std::fs::File::open(&second_result)
+            .unwrap()
+            .read_to_string(&mut data)
+            .unwrap();
         assert!(data == "error")
     }
 }
@@ -87,7 +99,10 @@ fn test_uid_gid() {
     let own_uid_gid_string = unsafe { format!("{} {}", libc::getuid(), libc::getgid()) };
 
     let mut data = String::new();
-    std::fs::File::open(&result_file).unwrap().read_to_string(&mut data).unwrap();
+    std::fs::File::open(&result_file)
+        .unwrap()
+        .read_to_string(&mut data)
+        .unwrap();
     assert!(!data.is_empty());
     assert!(data != own_uid_gid_string)
 }
@@ -104,10 +119,16 @@ fn test_redirect_streams() {
     std::thread::sleep(std::time::Duration::from_millis(100));
 
     let mut stdout = String::new();
-    std::fs::File::open(&stdout_file).unwrap().read_to_string(&mut stdout).unwrap();
+    std::fs::File::open(&stdout_file)
+        .unwrap()
+        .read_to_string(&mut stdout)
+        .unwrap();
 
     let mut stderr = String::new();
-    std::fs::File::open(&stderr_file).unwrap().read_to_string(&mut stderr).unwrap();
+    std::fs::File::open(&stderr_file)
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
 
     assert_eq!(stdout, "stdout\nnewline\n");
     assert_eq!(stderr, "stderr\nnewline\n");


### PR DESCRIPTION
Introduces a new function `exit_action`, which registers a callback to be run by the original process just before it exits. It is useful when one wants to wait for a signal from the forked process before the exit, or print a notification for example.

Also formatted by accident, but can create a PR without formatting if preferred.