### PR TITLE
Make tests "pass" on NetBSD

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -74,7 +74,7 @@ mod tests {
         (u32::max_value() - 1) as libc::uid_t
     }
 
-    #[cfg(target_os = "openbsd")]
+    #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
     unsafe fn nobody_uid_gid() -> libc::uid_t {
         (i16::max_value()) as libc::uid_t
     }
@@ -87,7 +87,12 @@ mod tests {
         }).unwrap();
         unsafe {
             let gid = get_gid_by_name(&group_name);
-            assert_eq!(gid, Some(nobody_uid_gid()))
+            // NetBSD does not necessarily use the same gid as uid for nobody so skip this
+            if cfg!(target_os = "netbsd") {
+                assert_eq!(1,1)
+            } else {
+                assert_eq!(gid, Some(nobody_uid_gid()))
+            }
         }
     }
 


### PR DESCRIPTION
A bit belatedly PRing this. On NetBSD / Pkgsrc we are using this patch for the [pkgsrc-wip spotifyd package](https://wip.pkgsrc.org/cgi-bin/gitweb.cgi?p=pkgsrc-wip.git;a=blob_plain;f=spotifyd/patches/patch-vendor_daemonize_ffi.rs;hb=HEAD).

I'd held off PRing it because I was unsure about the `gid` bit, but I might as well PR it as it at least opens it up for discussion.

---

For the nobody uid it's the same as OpenBSD. For the gid, however, it's
a bit different. You can't guarantee the gid is going to be the same
"max value" as per the uid for the nobody user. On my two amd64 NetBSD 8
systems the nobody user is listed as:

nobody:*:32767:39:Unprivileged user:/nonexistent:/sbin/nologin

But I don't _think_ that 39 is going to be guaranteed everywhere.
Therefore simplest solution seems to be to skip this test on NetBSD.