### PR TITLE
Never close explicitly, dup2 will close fd atomically before dup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,7 +450,6 @@ unsafe fn redirect_standard_streams(stdin: Stdio, stdout: Stdio, stderr: Stdio) 
     }
 
     let process_stdio = |fd, stdio: Stdio| {
-        tryret!(close(fd), (), DaemonizeError::RedirectStreams);
         match stdio.inner {
             StdioImp::Devnull => {
                 tryret!(dup2(devnull_fd, fd), (), DaemonizeError::RedirectStreams);


### PR DESCRIPTION
See more details at https://man7.org/linux/man-pages/man3/dup2.3p.html :
"On the other hand, the dup2() function provides unique services,
as no other interface is able to atomically replace
an existing file descriptor."