### PR TITLE
Ensure pid file ends with line separator

### DIFF
--- a/daemonize-tests/tests/tests.rs
+++ b/daemonize-tests/tests/tests.rs
@@ -38,7 +38,9 @@ fn pid() {
         .pid_file(&path)
         .sleep(std::time::Duration::from_secs(5))
         .run();
-    let pid = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+    let pid_content = std::fs::read_to_string(&path).unwrap();
+    assert!(pid_content.ends_with('\n'));
+    let pid = pid_content[..pid_content.len() - 1].parse().unwrap();
     assert_eq!(result.unwrap().pid, pid);
 
     let result = Tester::new().pid_file(&path).run();

--- a/daemonize/src/lib.rs
+++ b/daemonize/src/lib.rs
@@ -537,7 +537,7 @@ unsafe fn chown_pid_file(
 
 unsafe fn write_pid_file(fd: libc::c_int) -> Result<(), ErrorKind> {
     let pid = libc::getpid();
-    let pid_buf = format!("{}", pid).into_bytes();
+    let pid_buf = format!("{}\n", pid).into_bytes();
     let pid_length = pid_buf.len();
     let pid_c = CString::new(pid_buf).unwrap();
     check_err(libc::ftruncate(fd, 0), ErrorKind::TruncatePidfile)?;


### PR DESCRIPTION
Add line separator to pid file since systemd shows the warning log:
```
Failed to parse PID from file foo.pid: Invalid argument
```