### PR TITLE
include license files in published crates

### DIFF
--- a/daemonize/LICENSE-APACHE
+++ b/daemonize/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/daemonize/LICENSE-MIT
+++ b/daemonize/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Since the daemonize crate was split off into a separate workspace member, license files are no longer included in crates that are published to crates.io. Both the Apache-2.0 and the MIT licenses require that redistributed sources contain a copy of the license text, which is no longer the case since v0.5.0.

This PR adds symbolic links in the "daemonize" directory for "cargo package" / "cargo publish" to pick up (if you run "cargo publish" on a Windows system, this might not be enough though).