### PR TITLE
Change `setuid` Calls to `setreuid`, and the Same for `setgid`.

### DIFF
--- a/daemonize/src/lib.rs
+++ b/daemonize/src/lib.rs
@@ -354,7 +354,9 @@ impl<T> Daemonize<T> {
                 Ok(Some(first_child_pid)) => {
                     Outcome::Parent(match waitpid(first_child_pid) {
                         Err(err) => Err(err.into()),
-                        Ok(first_child_exit_code) => Ok(Parent { first_child_exit_code }),
+                        // return value of `waitpid` may not be i32 on all platforms.
+                        #[allow(clippy::unnecessary_cast)]
+                        Ok(first_child_exit_code) => Ok(Parent { first_child_exit_code: first_child_exit_code as i32 }),
                     })
                 },
                 Err(err) => Outcome::Parent(Err(err.into())),

--- a/daemonize/src/lib.rs
+++ b/daemonize/src/lib.rs
@@ -354,7 +354,7 @@ impl<T> Daemonize<T> {
                 Ok(Some(first_child_pid)) => {
                     Outcome::Parent(match waitpid(first_child_pid) {
                         Err(err) => Err(err.into()),
-                        Ok(first_child_exit_code) => Ok(Parent { first_child_exit_code: first_child_exit_code as i32 }),
+                        Ok(first_child_exit_code) => Ok(Parent { first_child_exit_code }),
                     })
                 },
                 Err(err) => Outcome::Parent(Err(err.into())),
@@ -498,7 +498,7 @@ unsafe fn get_group(group: Group) -> Result<libc::gid_t, ErrorKind> {
 }
 
 unsafe fn set_group(group: libc::gid_t) -> Result<(), ErrorKind> {
-    check_err(libc::setgid(group), ErrorKind::SetGroup)?;
+    check_err(libc::setregid(group, group), ErrorKind::SetGroup)?;
     Ok(())
 }
 
@@ -516,7 +516,7 @@ unsafe fn get_user(user: User) -> Result<libc::uid_t, ErrorKind> {
 }
 
 unsafe fn set_user(user: libc::uid_t) -> Result<(), ErrorKind> {
-    check_err(libc::setuid(user), ErrorKind::SetUser)?;
+    check_err(libc::setreuid(user, user), ErrorKind::SetUser)?;
     Ok(())
 }
 


### PR DESCRIPTION
As described in section 8.1 of https://people.eecs.berkeley.edu/~daw/papers/setuid-usenix02.pdf, setuid should be avoided because of its inconsistent implementation across different unix systems. Instead, setreuid should be used, as it is more consistent across systems.

As well, in the execute function there was a small snipped of code that I couldn't see why it existed, so I refactored it slightly.

It could be worth looking into also forcing the `chdir` directory, to be in the `chroot` directory, if you are enabling a `chroot`. As well, then it would be possible to reliably set the `PWD` environment variable. The `PWD` environment variable is not changed by the `chroot`, although it is possible that the current working directory is.