### PR TITLE
fix UB in Daemonize::privileged_action

### DIFF
--- a/daemonize/src/lib.rs
+++ b/daemonize/src/lib.rs
@@ -51,7 +51,6 @@ use std::env::set_current_dir;
 use std::ffi::CString;
 use std::fmt;
 use std::fs::File;
-use std::mem::transmute;
 use std::os::unix::ffi::OsStringExt;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -320,9 +319,19 @@ impl<T> Daemonize<T> {
     /// Execute `action` just before dropping privileges. Most common use case is to open
     /// listening socket. Result of `action` execution will be returned by `start` method.
     pub fn privileged_action<N, F: FnOnce() -> N + 'static>(self, action: F) -> Daemonize<N> {
-        let mut new: Daemonize<N> = unsafe { transmute(self) };
-        new.privileged_action = Box::new(action);
-        new
+        Daemonize {
+            directory: self.directory,
+            pid_file: self.pid_file,
+            chown_pid_file: self.chown_pid_file,
+            user: self.user,
+            group: self.group,
+            umask: self.umask,
+            root: self.root,
+            privileged_action: Box::new(action),
+            stdin: self.stdin,
+            stdout: self.stdout,
+            stderr: self.stderr,
+        }
     }
 
     /// Configuration for the child process's standard output stream.


### PR DESCRIPTION
Fixes UB in `Daemonize::privileged_action` by removing the transmute from `Daemonize<T>` to `Daemonize<N>`.

Transmuting between `Daemonize<T>` and `Daemonize<N>` is not guaranteed to be valid, as the transmute may temporarily put `self.privileged_action` into an invalid state. 

The type layout of `Daemonize<T>` and `Daemonize<N>` are also not guaranteed to be equivalent, since the compiler may reorder the fields of different instances of the same generic type according to the [Transmutes section of the Rustonomicon](https://doc.rust-lang.org/nomicon/transmutes.html#transmutes).

The solution used is to construct a `Daemonize<N>` manually and fill in the common fields from `self`, rather than transmuting and replacing just the `privileged_action` field.